### PR TITLE
Add data subfolders to template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 
 # Ignorera allt i data/
-data/*
-!data/.gitkeep
+data/**
+!data/**/.gitkeep

--- a/README.md
+++ b/README.md
@@ -5,4 +5,4 @@ Detta projekt är strukturerat enligt Sävsjö kommuns riktlinjer.
 ## Struktur
 - `src/` – programkod
 - `tests/` – testmoduler
-- `data/` – ej versionerad data
+- `data/` – ej versionerad data (`raw/`, `processed/`, `output/`)

--- a/src/skapa.py
+++ b/src/skapa.py
@@ -3,7 +3,11 @@ from datetime import datetime
 
 PROJEKTMALLAR = {
     "python": {
-        "data": [],
+        "data": [
+            "raw/.gitkeep",
+            "processed/.gitkeep",
+            "output/.gitkeep",
+        ],
         "dokumentation": ["README.md"],
         "src": ["__init__.py"],
         "tests": [],
@@ -21,8 +25,18 @@ PROJEKTMALLAR = {
 }
 
 GITIGNORE_REGLER = {
-    "python": ["# Ignorera allt i data/", "data/*", "!data/.gitkeep"],
-    "webb": ["# Ignorera node_modules och byggfiler", "node_modules/", "dist/", "data/*", "!data/.gitkeep"]
+    "python": [
+        "# Ignorera allt i data/",
+        "data/**",
+        "!data/**/.gitkeep",
+    ],
+    "webb": [
+        "# Ignorera node_modules och byggfiler",
+        "node_modules/",
+        "dist/",
+        "data/**",
+        "!data/**/.gitkeep",
+    ],
 }
 
 EDITORCONFIG_INNEHALL = """root = true


### PR DESCRIPTION
## Summary
- add `raw`, `processed` and `output` subfolders under `data` when creating projects
- ignore all files in `data/` except `.gitkeep` files
- document new subfolders in README

## Testing
- `python -m py_compile src/skapa.py`

------
https://chatgpt.com/codex/tasks/task_b_688c601b92588328aa1bb60599008d0e